### PR TITLE
Add curl error message to exception output

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -171,7 +171,8 @@ class Client
 
         // Error handling
         if (substr(strval($httpCode), 0, 1) !== "2" && $httpCode !== 404 && $httpCode !== 400) {
-            throw new \Exception('Unhandled HTTP code from response: ' . $httpCode, 1);
+            $message = isset(json_decode($response)->message) ? '. Error message: ' . json_decode($response)->message : '';
+            throw new \Exception('Unhandled HTTP code from response: ' . $httpCode . $message, 1);
         }
 
         return $response;

--- a/src/Client.php
+++ b/src/Client.php
@@ -172,7 +172,7 @@ class Client
         // Error handling
         if (substr(strval($httpCode), 0, 1) !== "2" && $httpCode !== 404 && $httpCode !== 400) {
             $message = isset(json_decode($response)->message) ? '. Error message: ' . json_decode($response)->message : '';
-            throw new \Exception('Unhandled HTTP code from response: ' . $httpCode . $message, 1);
+            throw new \Exception("Unhandled HTTP code({$httpCode}) from response: " . $message, 1);
         }
 
         return $response;


### PR DESCRIPTION
Hi Rasmus.
What do you think about this addition. It will add more info to the exception message and give a better idea about what failed.

Before:
"PHP Fatal error:  Uncaught Exception: Unhandled HTTP code from response: 401 in ..."

After:
"PHP Fatal error:  Uncaught Exception: Unhandled HTTP code from response: 401. Error message: Bad token; invalid JSON in ..."

Please check for introduced bugs or bad coding!