### PR TITLE
Fix variable and function names.

### DIFF
--- a/examples/orders.php
+++ b/examples/orders.php
@@ -17,11 +17,17 @@ Client::getInstance(
     $config['api_path'] ?? null
 );
 
-/* $result = Order::getCustomerInvoice('76721300', 'TESTAGCO');
+/*
+var_dump(
+$result = Order::getInvoice('76721300', 'TESTAGCO');
+);
 
 var_dump(
-    $result
-); */
+    'inbox: ' . Order::getSalesIntegrationInbox('76721300','TEST-jhj-5')->getData()->externalDocumentNumber, // inbox table
+    'order: ' . Order::getSalesOrderExternalId('76721300','TEST-jhj-5')->getData()->external_document_number, // order table
+    Order::getInvoice('76721300','TEST-jhj-5')->getData()->invoices->external_document_number // invoice table
+);
+*/
 
 var_dump(
     Order::create([

--- a/src/ApiObjects/Order.php
+++ b/src/ApiObjects/Order.php
@@ -44,28 +44,28 @@ class Order
     public static function getSalesOrders($customerId, $orderId)
     {
         $apiPath = Client::getInstance()->getApiPath(self::$apiPath);
-        $result  = Client::getInstance()->get($apiPath . '/sales-orders', ['customer_id' => $customerId, 'order_id' => $orderId]);
+        $result  = Client::getInstance()->get($apiPath . '/sales-orders', ['customer_number' => $customerId, 'order_id' => $orderId]);
 
         return new ApiObjectResult($result, __METHOD__, 0, [$customerId, $orderId]);
     }
 
-    public static function getSalesOrderExternalId($customerId, $orderId)
+    public static function getSalesOrderExternalId($customerNumber, $orderId)
     {
         $apiPath = Client::getInstance()->getApiPath(self::$apiPath);
-        $result  = Client::getInstance()->get($apiPath . '/sales-orders-by-external-order-id', ['customer_id' => $customerId, 'order_id' => $orderId]);
+        $result  = Client::getInstance()->get($apiPath . '/sales-orders-by-external-order-id', ['customer_number' => $customerNumber, 'order_id' => $orderId]);
 
-        return new ApiObjectResult($result, __METHOD__, 0, [$customerId, $orderId]);
+        return new ApiObjectResult($result, __METHOD__, 0, [$customerNumber, $orderId]);
     }
 
-    public static function getCustomerInvoice($customerId, $documentNumber)
+    public static function getInvoice($customerNumber, $documentNumber)
     {
         $apiPath = Client::getInstance()->getApiPath(self::$apiPath);
-        $result  = Client::getInstance()->get($apiPath . '/invoice/customer', ['customer_number' => $customerId, 'order_id' => $documentNumber]);
+        $result  = Client::getInstance()->get($apiPath . '/invoice/customer', ['customer_number' => $customerNumber, 'order_id' => $documentNumber]);
 
-        return new ApiObjectResult($result, __METHOD__, 0, [$customerId, $documentNumber]);
+        return new ApiObjectResult($result, __METHOD__, 0, [$customerNumber, $documentNumber]);
     }
 
-    public static function getCustomerSalesIntegrationInbox($customerId, $documentNumber)
+    public static function getSalesIntegrationInbox($customerId, $documentNumber)
     {
         $apiPath = Client::getInstance()->getApiPath(self::$apiPath);
         $result  = Client::getInstance()->get($apiPath . '/sales-integration-inbox', ['customer_number' => $customerId, 'order_id' => $documentNumber]);


### PR DESCRIPTION
- Function names to be general without customer specific therminology.
- Use the same names for the same thing. Use customer_number instead of customer_id, since this is what it is called in DSM.

Fixes: AB#40764