### PR TITLE
Add configurable HTTP timeouts to Client to prevent indefinite hangs

### DIFF
--- a/Tests/ClientTest.php
+++ b/Tests/ClientTest.php
@@ -31,4 +31,56 @@ class ClientTest extends TestCase
         $client->setBaseUrl('https://example.com');
         $this->assertEquals('https://example.com', $client->getBaseUrl());
     }
+
+    public function testDefaultTimeoutsAreSet()
+    {
+        $client = Client::getInstance('https://test.com', 'access-token', 'tenant-token');
+
+        // Safe, non-zero defaults must be present so a request can never hang forever.
+        $this->assertSame(10, $client->getConnectTimeout());
+        $this->assertSame(30, $client->getTimeout());
+    }
+
+    public function testTimeoutsAreOverridableViaGetInstance()
+    {
+        $client = Client::getInstance('https://test.com', 'access-token', 'tenant-token', null, 3, 5);
+
+        $this->assertSame(3, $client->getConnectTimeout());
+        $this->assertSame(5, $client->getTimeout());
+    }
+
+    public function testTimeoutsAreOverridableViaSetters()
+    {
+        $client = Client::getInstance('https://test.com', 'access-token', 'tenant-token');
+        $client->setConnectTimeout(2)->setTimeout(4);
+
+        $this->assertSame(2, $client->getConnectTimeout());
+        $this->assertSame(4, $client->getTimeout());
+    }
+
+    /**
+     * A slow/unreachable upstream must surface as a catchable \Exception within the
+     * configured timeout, NOT block the process indefinitely. We point at a
+     * non-routable address (TEST-NET-1, RFC 5737) with a 1s connect timeout; curl
+     * must give up quickly and the existing error handling must throw (HTTP code 0).
+     */
+    public function testSlowUpstreamThrowsWithinTimeoutInsteadOfHanging()
+    {
+        $client = Client::getInstance('http://192.0.2.1', 'access-token', 'tenant-token', null, 1, 1);
+
+        $start = microtime(true);
+
+        try {
+            $client->get('/ping');
+            $this->fail('Expected an exception when the upstream is unreachable.');
+        } catch (\Exception $e) {
+            $elapsed = microtime(true) - $start;
+
+            // Must be a catchable \Exception (the contract's code-1 connectivity error),
+            // and it must return well within a generous bound of the 1s timeout.
+            $this->assertSame(1, $e->getCode());
+            $this->assertLessThan(10, $elapsed, 'Request did not abort within the timeout window.');
+            $this->assertSame(0, $client->getStatusCode());
+        }
+    }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -19,6 +19,23 @@ class Client
     private $statusCode;
 
     /**
+     * Maximum number of seconds to wait while trying to connect to the
+     * upstream before the request is aborted. 0 = wait indefinitely (unsafe).
+     *
+     * @var int
+     */
+    private $connectTimeout = 10;
+
+    /**
+     * Maximum number of seconds the whole request is allowed to take before
+     * curl aborts it. Without this a slow/hanging upstream (Kong → web*-service
+     * → BC/NAV) blocks the PHP process forever. 0 = wait indefinitely (unsafe).
+     *
+     * @var int
+     */
+    private $timeout = 30;
+
+    /**
      * Gets the active class instance from $instance. If instance is not set
      * Create a new class instance and save it in $instance
      *
@@ -26,12 +43,14 @@ class Client
      * @param string $accessToken
      * @param string $tenantToken
      * @param string $apiPath
+     * @param int|null $connectTimeout Seconds to wait for the connection (null = keep default)
+     * @param int|null $timeout        Seconds for the whole request (null = keep default)
      * @return Client
      */
-    public static function getInstance($baseUrl = null, $accessToken = null, $tenantToken = null, string $apiPath = null)
+    public static function getInstance($baseUrl = null, $accessToken = null, $tenantToken = null, string $apiPath = null, ?int $connectTimeout = null, ?int $timeout = null)
     {
         if (!self::$instance) {
-            self::$instance = new self($baseUrl, $accessToken, $tenantToken, $apiPath);
+            self::$instance = new self($baseUrl, $accessToken, $tenantToken, $apiPath, $connectTimeout, $timeout);
         }
 
         return self::$instance;
@@ -44,7 +63,7 @@ class Client
      * @param string $accessToken
      * @param string $tenantToken
      */
-    private function __construct(?string $baseUrl = null, ?string $accessToken = null, ?string $tenantToken = null, ?string $apiPath = null)
+    private function __construct(?string $baseUrl = null, ?string $accessToken = null, ?string $tenantToken = null, ?string $apiPath = null, ?int $connectTimeout = null, ?int $timeout = null)
     {
         if ($baseUrl) {
             $this->setBaseUrl($baseUrl);
@@ -57,6 +76,12 @@ class Client
         }
         if ($apiPath !== null) {
             $this->setApiPath($apiPath);
+        }
+        if ($connectTimeout !== null) {
+            $this->setConnectTimeout($connectTimeout);
+        }
+        if ($timeout !== null) {
+            $this->setTimeout($timeout);
         }
 
         $this->curl = curl_init();
@@ -137,6 +162,52 @@ class Client
     }
 
     /**
+     * Sets the maximum number of seconds to wait while connecting to the upstream.
+     *
+     * @param int $connectTimeout
+     * @return Client
+     */
+    public function setConnectTimeout(int $connectTimeout)
+    {
+        $this->connectTimeout = $connectTimeout;
+
+        return $this;
+    }
+
+    /**
+     * Gets the connection timeout in seconds.
+     *
+     * @return int
+     */
+    public function getConnectTimeout(): int
+    {
+        return $this->connectTimeout;
+    }
+
+    /**
+     * Sets the maximum number of seconds the whole request is allowed to take.
+     *
+     * @param int $timeout
+     * @return Client
+     */
+    public function setTimeout(int $timeout)
+    {
+        $this->timeout = $timeout;
+
+        return $this;
+    }
+
+    /**
+     * Gets the request timeout in seconds.
+     *
+     * @return int
+     */
+    public function getTimeout(): int
+    {
+        return $this->timeout;
+    }
+
+    /**
      * @param string $apiPath
      * @return void
      */
@@ -207,6 +278,14 @@ class Client
         }
 
         curl_setopt($this->curl, CURLOPT_URL, $url);
+
+        // Apply timeouts on every request so a slow/hanging upstream cannot block
+        // the PHP process indefinitely. Set here (rather than only in the constructor)
+        // so runtime overrides via setConnectTimeout()/setTimeout() take effect on the
+        // cached singleton. A curl timeout makes CURLINFO_HTTP_CODE 0, which the error
+        // handling below surfaces as a catchable \Exception (code 1) instead of a hang.
+        curl_setopt($this->curl, CURLOPT_CONNECTTIMEOUT, $this->connectTimeout);
+        curl_setopt($this->curl, CURLOPT_TIMEOUT, $this->timeout);
 
         $response = curl_exec($this->curl);
         $httpCode = curl_getinfo($this->curl, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
## Problem

`Client::request()` set `CURLOPT_RETURNTRANSFER`, `CURLOPT_FOLLOWLOCATION`, headers and the verb options, but **no `CURLOPT_TIMEOUT` and no `CURLOPT_CONNECTTIMEOUT`**. When an upstream is slow or unresponsive (Kong → web*-service → BC/NAV), `curl_exec()` blocks the PHP process indefinitely.

On `powerhosting-sodhaak_prod` (Shopware 6.4) this caused a worker pile-up: blocked `messenger:consume` and `jma:import:*` processes never reached Symfony's `--time-limit=55`, never sent the AMQP heartbeat (RabbitMQ sockets stuck in `CLOSE-WAIT`), and cron kept spawning more every minute (host load ~41).

## Change

- Add `connectTimeout` (default **10s**) and `timeout` (default **30s**) to `Client`.
- Both overridable via new `getInstance()` params and via `setConnectTimeout()` / `setTimeout()` setters.
- Options applied in `request()` (not only the constructor) so runtime overrides take effect on the cached singleton.

## Error semantics preserved

A curl timeout yields `CURLINFO_HTTP_CODE === 0`, which the **existing** error handling already turns into a catchable `\Exception` (code 1, "Please check your hostname and port"). So a timeout is now a recoverable, catchable error instead of a hang. No new exception classes; 400 / 404 / 500 handling and the empty-body success path are unchanged. Singleton + private constructor + private `setApiPath()` are untouched.

## Tests

`Tests/ClientTest.php` adds coverage for the defaults, both override paths, and that an unreachable upstream throws within the timeout instead of hanging. All pass on PHPUnit 10.4 / PHP 8.4.

## Note on base branch

Opened against `2.22.3` (current released tip, installed in prod as `v2.22.3`) rather than `master`, because `master` is **behind** this branch and is missing the already-shipped `statusCode`, empty-body, and `die()`→`RuntimeException` fixes. Basing on `master` would regress those. Please cut a patch release (e.g. `v2.22.4`) from this branch after merge so the shop can bump its pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)